### PR TITLE
Fixed typo and edits

### DIFF
--- a/dunedin/index.html
+++ b/dunedin/index.html
@@ -118,15 +118,14 @@
 	    </simple-columns>
       -->
     </section>
-    <h2>Prelinary timetable for workshops</h2>
-    This timetable is preliminary and subject to change. Please check back before the event for updates.
-    <br>
+    <h2>Preliminary timetable for workshops</h2>
+    This timetable is preliminary and subject to change. Please check back before the event for updates.</b>
     All workshops within a session are run concurrently in separate rooms. <b>Nearly all workshops will require you to bring a laptop.</b>
 
     <p>Skill level description:<br>
-      In order to convey the skill level of a particular workshop the following terms are used describe the level at which a participant could expect the amount of prior knowledge or experience to be assumed.
-      <i>Beginner</i>: This assumes that when pre-requisites are stated and met, someone new to the topic would be able to follow along and will have minimal assumed external knowledge<br>
-      <i>Post-beginner</i>: Has a greater expectation of external knowledge from the direct topic being covered that can be assumed
+      In order to convey the skill level of a particular workshop the following terms are used to describe the assumed levels of prior knowledge or experience.<br>
+      <i>Beginner</i>: Someone new to the topic with minimal prior knowledge of the workshop topic beyond the stated pre-requisites<br>
+      <i>Post-beginner</i>: Greater expectation of prior knowledge or experience beyond the direct topic being covered in the workshop
     </p>
     <section id="Day1">
       <h3>Monday 11th February</h3>
@@ -429,7 +428,7 @@
           </expandable-heading>
 
           <expandable-heading title="Research data management">
-            This session will cover...
+            This presentation will cover general best-practice principles of management, storage and sharing of research data. It will include practical tips for improving data management practices that can be implemented immediately regardless of the type of data. By attending students will feel better prepared to respond to university, employer, funder and/or publisher data requirements. 
 
             <p>Targeted skill level: all</p>
             <p>Software required: none</p>


### PR DESCRIPTION
Fixed typo "Prelinary" to "Preliminary". Edited Skill Level Description section to make it read a little better (see what you think). Added text for data management workshop. (Sorry - I'm aware I should have done these in three separate commits now - will remember for next time.)